### PR TITLE
Fix missing token secret on deployment

### DIFF
--- a/recipely-server/models/jwtAuth.js
+++ b/recipely-server/models/jwtAuth.js
@@ -1,8 +1,8 @@
 const moment = require('moment');
 const jwt = require('jwt-simple');
-const config = require('../config/config');
 
-const secretKey = process.env.TOKEN_SECRET || config.TOKEN_SECRET
+// only require config file if env variable doesn't exist (e.g. not running on heroku)
+const secretKey = process.env.TOKEN_SECRET || require('../config/config').TOKEN_SECRET;
 
 function encodeToken(userId, callback) {
   const payload = {


### PR DESCRIPTION
Only require the config file if we're running locally. Otherwise, use the TOKEN_SECRET environment variable. Closes #65 