### PR TITLE
Change the updating of notes to happen on client first

### DIFF
--- a/recipely-app/main.js
+++ b/recipely-app/main.js
@@ -103,8 +103,8 @@ class App extends Component {
     this.setState({isLoggedIn: !this.state.isLoggedIn});
   }
 
-  onNotesChange = (notes) => {
-    this.setState({notes});
+  onNotesChange = (notes, cb = () => {}) => {
+    this.setState({notes}, cb);
   };
 
   onPopularRecipesChange = (popularRecipes) => {

--- a/recipely-app/screens/AddNoteScreen.js
+++ b/recipely-app/screens/AddNoteScreen.js
@@ -42,10 +42,16 @@ class AddNoteScreen extends Component {
       })
       .then(newNote => {
         const notes = this.props.screenProps.notes;
-        this.props.screenProps.onNotesChange([ ...notes, newNote ]);
-        // // Need to trigger a render in previous component.
-        onGoBack(this.props.screenProps.notes.filter(
-          otherNote => newNote.f2f_id === otherNote.f2f_id)
+        this.props.screenProps.onNotesChange(
+          [ ...notes, newNote ],
+          // onNotesChange calls setState which is not synchronous. Need to wait
+          // for the new note to be added before we navigate user back.
+          () => {
+            // // Need to trigger a render in previous component.
+            onGoBack(this.props.screenProps.notes.filter(
+              otherNote => newNote.f2f_id === otherNote.f2f_id)
+            );
+          }
         );
         this.setState({isAdding: false});
       })


### PR DESCRIPTION
Previously, the updating of notes was sent as a POST request to our server. Then after successful request, we render the updated note.

Now, the updated note is rendered immediately. The POST request to the server is sent in the background with the assumption that it will be successful. 